### PR TITLE
Sorts card row based on rowData platformId instead of childCards.id

### DIFF
--- a/src/components/game-layout.js
+++ b/src/components/game-layout.js
@@ -44,6 +44,7 @@ export default GameLayout
 function rowFromData(rowData) {
   let idx = 0
   // console.log(rowData)
+  rowData.list.sort((cardA, cardB) => { return cardA.platform - cardB.platform })
   const childCards = rowData.list.map((record) => {
     return (
       <GameDataCard
@@ -64,7 +65,6 @@ function rowFromData(rowData) {
       />
     )
   })
-  childCards.sort((cardA, cardB) => { return cardA.id > cardB.id })
 
   return (
     <GameDataRow


### PR DESCRIPTION
Fixes reverse sorted cards in safari/chromium on macOS.