### PR TITLE
Refactor db resolution type

### DIFF
--- a/admin/data-editor.js
+++ b/admin/data-editor.js
@@ -45,13 +45,13 @@ async function postPerformanceRecord(recordIdBase, endpoint){
 
   const fpsTargVal = Number(document.querySelector(q('input', 'fps-target')).value)
   const resTargVal = Number(document.querySelector(q('input', 'resolution-target')).value)
-  const resTypeVal = document.querySelector(q('input','resolution-type') + ":checked")?.value
+  const resScalingVal = document.querySelector(q('input','resolution-scaling') + ":checked")?.value
 
   if (fpsTargVal === 0
     || resTargVal === 0
     || Number.isNaN(fpsTargVal)
     || Number.isNaN(resTargVal)
-    || typeof resTypeVal === 'undefined') {
+    || typeof resScalingVal === 'undefined') {
     alert('Please fill out all fields')
     return
   }
@@ -63,8 +63,7 @@ async function postPerformanceRecord(recordIdBase, endpoint){
     },
     resolution: {
       target: resTargVal,
-      dynamic: resTypeVal === 'dynamic',
-      checkerboard: resTypeVal === 'checkerboard'
+      scaling: resScalingVal
     }
   }
 
@@ -80,6 +79,7 @@ async function postPerformanceRecord(recordIdBase, endpoint){
 
   if (response.status === 200) {
     try {
+      await getSelectedGameData(targetGame.name)
       htmx.trigger('#performance-records-list', 'reload')
     } catch (e) { console.log(e) }
   }
@@ -98,10 +98,11 @@ async function deletePerformanceRecordByIndex(idx, endpoint){
   }
 }
 
-async function getSelectedGameData(event) {
+async function getSelectedGameData(name) {
+  console.log('getgamedata',name)
   if (gameLoaded === false) {
     gameLoaded = true
-    targetGame.name = event.detail.elt.value
+    targetGame.name = name
     try {
       const response = await fetch(`/data/game/` + targetGame.name, { method: `GET` })
       const json = await response.json()

--- a/admin/routes/page.mjs
+++ b/admin/routes/page.mjs
@@ -1,5 +1,3 @@
-import * as util from 'util'
-
 import Handlebars from 'handlebars'
 
 Handlebars.logger.level = 0
@@ -165,7 +163,7 @@ export default async function routePage(pageApi, options) {
     'performance-records': (gameData) => {
       sectionData['performance-records'].gfxOptions = gameData.gfxOptions
       sectionData['performance-records'].platforms = gameData.platforms
-      sectionData['performance-records'].resolutionTypes = ['full', 'dynamic', 'checkerboard']
+      sectionData['performance-records'].resolutionScalingOpts = ['full', 'dynamic', 'upscaled']
       sectionData['performance-records'].list = gameData.performanceRecords.map((record, idx) => {
         return {
           index: idx,
@@ -175,9 +173,9 @@ export default async function routePage(pageApi, options) {
     }
   }
 
-  const Q = (obj, depth = 2) => {
-    return util.inspect(obj, { depth: depth, colors: true })
-  }
+  // const Q = (obj, depth = 2) => {
+  //   return util.inspect(obj, { depth: depth, colors: true })
+  // }
 
   function capitalize(str) {
     let Str = ''

--- a/admin/ui/game-select.template.html
+++ b/admin/ui/game-select.template.html
@@ -5,7 +5,7 @@
   hx-target="#game-data-editor"
   hx-swap="innerHTML"
   onchange="gameLoaded = false"
-  hx-on:htmx:after-request="getSelectedGameData(event)"
+  hx-on:htmx:after-request="getSelectedGameData(event.detail.elt.value)"
 >
   {{#each gamesList}}
   <option

--- a/admin/ui/performance-records.template.html
+++ b/admin/ui/performance-records.template.html
@@ -40,11 +40,11 @@
     pattern="\d{3,}" />
   <br />
 
-  <span>resolution type</span>
-  {{#each resolutionTypes}}
-  <input type="radio" id="{{@root.endpoint}}-new-resolution-type-{{this}}"
-    name="{{@root.endpoint}}-new-resolution-type" value="{{this}}" />
-  <label for="{{@root.endpoint}}-new-resolution-type-{{this}}">{{this}}</label>
+  <span>resolution scaling</span>
+  {{#each resolutionScalingOpts}}
+  <input type="radio" id="{{@root.endpoint}}-new-resolution-scaling-{{this}}"
+    name="{{@root.endpoint}}-new-resolution-scaling" value="{{this}}" />
+  <label for="{{@root.endpoint}}-new-resolution-scaling-{{this}}">{{this}}</label>
   {{/each}}
 
   <br />
@@ -80,12 +80,7 @@
   <h4>Resolution</h4>
   <p>
     target: {{resolution.target}}
-    {{#if resolution.dynamic}}
-    dynamic
-    {{/if}}
-    {{#if resolution.checkerboard}}
-    checkerboard
-    {{/if}}
+    {{resolution.scaling}}
   </p>
 </fieldset>
 {{/each}}

--- a/data/games/diablo-iv.json
+++ b/data/games/diablo-iv.json
@@ -46,8 +46,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": true
+        "scaling": "upscaled"
       }
     },
     {
@@ -62,8 +61,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": true
+        "scaling": "upscaled"
       }
     },
     {
@@ -78,8 +76,7 @@
       },
       "resolution": {
         "target": 1080,
-        "dynamic": false,
-        "checkerboard": true
+        "scaling": "upscaled"
       }
     }
   ]

--- a/data/games/dragon's-dogma-2.json
+++ b/data/games/dragon's-dogma-2.json
@@ -44,8 +44,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -60,8 +59,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -76,8 +74,7 @@
       },
       "resolution": {
         "target": 1440,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     }
   ]

--- a/data/games/elden-ring.json
+++ b/data/games/elden-ring.json
@@ -69,8 +69,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -94,8 +93,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -119,8 +117,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": true,
-        "checkerboard": false
+        "scaling": "dynamic"
       }
     },
     {
@@ -144,8 +141,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -169,8 +165,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -195,9 +190,8 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": true,
-        "checkerboard": false,
-        "note": "small paragraph"
+        "note": "small paragraph",
+        "scaling": "dynamic"
       }
     },
     {
@@ -221,8 +215,7 @@
       },
       "resolution": {
         "target": 1440,
-        "dynamic": true,
-        "checkerboard": false
+        "scaling": "dynamic"
       }
     },
     {
@@ -247,9 +240,8 @@
       },
       "resolution": {
         "target": 1440,
-        "dynamic": false,
-        "checkerboard": false,
-        "note": "small paragraph"
+        "note": "small paragraph",
+        "scaling": "full"
       }
     }
   ]

--- a/data/games/like-a-dragon:-infinite-wealth.json
+++ b/data/games/like-a-dragon:-infinite-wealth.json
@@ -45,8 +45,7 @@
       },
       "resolution": {
         "target": 1440,
-        "dynamic": true,
-        "checkerboard": false
+        "scaling": "dynamic"
       }
     },
     {
@@ -61,8 +60,7 @@
       },
       "resolution": {
         "target": 1440,
-        "dynamic": true,
-        "checkerboard": false
+        "scaling": "dynamic"
       }
     },
     {
@@ -77,8 +75,7 @@
       },
       "resolution": {
         "target": 900,
-        "dynamic": true,
-        "checkerboard": false
+        "scaling": "dynamic"
       }
     }
   ]

--- a/data/games/mlb-the-show-24.json
+++ b/data/games/mlb-the-show-24.json
@@ -46,8 +46,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -62,8 +61,7 @@
       },
       "resolution": {
         "target": 1080,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -78,8 +76,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     }
   ]

--- a/data/games/persona-3-reload.json
+++ b/data/games/persona-3-reload.json
@@ -42,8 +42,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -58,8 +57,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -74,8 +72,7 @@
       },
       "resolution": {
         "target": 1080,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     }
   ]

--- a/data/games/prince-of-persia:-the-lost-crown.json
+++ b/data/games/prince-of-persia:-the-lost-crown.json
@@ -59,8 +59,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -80,8 +79,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -101,8 +99,7 @@
       },
       "resolution": {
         "target": 1440,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -122,8 +119,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     },
     {
@@ -143,8 +139,7 @@
       },
       "resolution": {
         "target": 2160,
-        "dynamic": false,
-        "checkerboard": false
+        "scaling": "full"
       }
     }
   ]

--- a/src/components/game-data-card.js
+++ b/src/components/game-data-card.js
@@ -8,7 +8,7 @@ const GameDataCard = ({ resolutionData, fpsData, rayTracing = false }) => {
       <div className={Style.gameDataCardMain}>
         <div>
           <b>{resolutionData.value}p</b><br />
-          {resolutionData.type}
+          {resolutionData.scaling}
         </div>
         <div>
           <b>{fpsData.value} fps</b><br />

--- a/src/components/game-layout.js
+++ b/src/components/game-layout.js
@@ -52,7 +52,7 @@ function rowFromData(rowData) {
         resolutionData={
           {
             value: record.resolutionData.target,
-            type: record.resolutionData.dynamic ? "dynamic" : "full"
+            scaling: record.resolutionData.scaling
           }
         }
         fpsData={

--- a/src/pages/game/{gamesJson.title}.js
+++ b/src/pages/game/{gamesJson.title}.js
@@ -238,10 +238,9 @@ query ($id: String) {
           target
         }
         resolution {
-          checkerboard
-          dynamic
           note
           target
+          scaling
         }
       }
       platforms


### PR DESCRIPTION
Note: no canonical location exists to typecheck `resolution.scaling` for valid scaling types. Currently `admin/routes/page.mjs` is the only location that contains any type restrictions: `[ 'full', 'dynamic', 'upscaled' ]`.